### PR TITLE
Bugfix guitarix jack server call

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This allows the dbus-compiled jack server to run without a GUI running.
 ### **II6:** Installing music stuff and configuring it
 
 Install this stuff!
-`sudo apt-get install qjackctl jackd2 guitarix aj-snapshot puredata git pd-ggee`
+`sudo apt-get install qjackctl jackd2 guitarix aj-snapshot puredata git pd-ggee a2jmidid`
 
 - Jackd2 (jackd2) is audio server
 - qjackctl is a QT-based GUI to manage jackd2 server. There are others if you prefer.
@@ -172,6 +172,7 @@ Install this stuff!
 - aj-snapshot is the automatic audio/midi auto connection daemon. May be able to replace this with `--jack-autoconnect` (and similar CLI flags) on guitarix and amsynth.
 - git to clone this repo
 - puredata and pd-ggee for MIDI translation and script launching on MIDI message
+- a2jmidid for alsa to jack midi bridging
 
 Allow jack server to use realtime priority (it'll ask when you're installing. Say yes.)
 

--- a/bash/dspiSwitcher.sh
+++ b/bash/dspiSwitcher.sh
@@ -10,7 +10,7 @@ if [ "${#1}" -gt "0" ]; then
 fi
 
 [ $dspi == 'guitarix' ] && (
-  jackd -s -S -P80 -p16 -t2000 -dalsa -dhw:CODEC,0 -r48000 -p64 -n6 -s -S -D -Xnone >> /home/pi/DSPi/jackboot.log &
+  jackd -s -S -P80 -p16 -t2000 -dalsa -dhw:CODEC,0 -r48000 -p64 -n6 -s -S -D -Xseq >> /home/pi/DSPi/jackboot.log &
   # chrt -a -r -p 80 $! &
   sleep 15
   guitarix --nogui -t >> /home/pi/DSPi/jackboot.log &

--- a/bash/dspiSwitcher.sh
+++ b/bash/dspiSwitcher.sh
@@ -10,13 +10,13 @@ if [ "${#1}" -gt "0" ]; then
 fi
 
 [ $dspi == 'guitarix' ] && (
-  jackd -P80 -p16 -S -t2000 -dalsa -dhw:CODEC,0 -p64 -n6 -r48000 -s -S -Xseq -D >> /home/pi/DSPi/jackboot.log &
+  jackd -s -S -P80 -p16 -t2000 -dalsa -dhw:CODEC,0 -r48000 -p64 -n6 -s -S -D -Xnone >> /home/pi/DSPi/jackboot.log &
   # chrt -a -r -p 80 $! &
   sleep 15
-  guitarix --nogui >> /home/pi/DSPi/jackboot.log &
+  guitarix --nogui -t >> /home/pi/DSPi/jackboot.log &
   chrt -a -r -p 75 $! &
   echo "nernerner"
-  sudo ifdown wlan0 &
+  # sudo ifdown wlan0 &
   exit 0;
 )
 [ $dspi == 'amsynth' ] && (

--- a/bash/dspiSwitcher.sh
+++ b/bash/dspiSwitcher.sh
@@ -18,7 +18,7 @@ fi
   guitarix --nogui -t >> /home/pi/DSPi/jackboot.log &
   chrt -a -r -p 75 $! &
   echo "nernerner"
-  # sudo ifdown wlan0 &
+  sudo ifdown wlan0 &
   exit 0;
 )
 [ $dspi == 'amsynth' ] && (

--- a/bash/dspiSwitcher.sh
+++ b/bash/dspiSwitcher.sh
@@ -3,6 +3,7 @@ export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 killall -9 amsynth
 killall -9 guitarix
 killall -9 jackd
+killall -9 a2jmidid
 
 # This checks to see if an arguement was passed in. This overwrites the dspi environment variable
 if [ "${#1}" -gt "0" ]; then
@@ -10,9 +11,10 @@ if [ "${#1}" -gt "0" ]; then
 fi
 
 [ $dspi == 'guitarix' ] && (
-  jackd -s -S -P80 -p16 -t2000 -dalsa -dhw:CODEC,0 -r48000 -p64 -n6 -s -S -D -Xseq >> /home/pi/DSPi/jackboot.log &
+  jackd -s -S -P80 -p16 -t2000 -dalsa -dhw:CODEC,0 -r48000 -p64 -n6 -s -S -D -Xnone >> /home/pi/DSPi/jackboot.log &
   # chrt -a -r -p 80 $! &
   sleep 15
+  a2jmidid &
   guitarix --nogui -t >> /home/pi/DSPi/jackboot.log &
   chrt -a -r -p 75 $! &
   echo "nernerner"

--- a/configs/aj-snapshot.xml
+++ b/configs/aj-snapshot.xml
@@ -6,6 +6,7 @@
   <client name="Midi Fighter Twister"> <!-- Dirty MFT Signal -->
     <port id="0">
       <connection client="Pure Data" port="1" />
+      <connection client="Midi Through" port="0" />
     </port>
   </client>
   <client name="QuNexus">
@@ -51,11 +52,13 @@
     </port>
     <port name="capture_2" />
   </client>
+
   <client name="gx_head_amp">
     <port name="out_0">
       <connection port="gx_head_fx:in_0" />
     </port>
   </client>
+
   <client name="gx_head_fx">
     <port name="out_0">
       <connection port="system:playback_1" />
@@ -64,5 +67,11 @@
       <connection port="system:playback_2" />
     </port>
   </client>
-</jack>
 
+  <client name="a2j">
+    <port name="Midi Through [14] (capture): Midi Through Port-0">
+      <connection port="gx_head_amp:midi_in_1" />
+    </port>
+  </client>
+
+</jack>

--- a/configs/aj-snapshot.xml
+++ b/configs/aj-snapshot.xml
@@ -44,24 +44,12 @@
     </port>
   </client>
 </alsa>
-<!-- Guitarix should do this itself...
 <jack>
-  <client name="amsynth">
-    <port name="L out">
-      <connection port="system:playback_1" />
-    </port>
-    <port name="R out">
-      <connection port="system:playback_2" />
-    </port>
-    <port name="midi_out" />
-  </client>
   <client name="system">
     <port name="capture_1">
       <connection port="gx_head_amp:in_0" />
     </port>
-    <port name="midi_capture_1">
-      <connection port="gx_head_amp:midi_in_1" />
-    </port>
+    <port name="capture_2" />
   </client>
   <client name="gx_head_amp">
     <port name="out_0">
@@ -77,4 +65,4 @@
     </port>
   </client>
 </jack>
--->
+

--- a/raspi-playbook.yml
+++ b/raspi-playbook.yml
@@ -36,6 +36,7 @@
       - puredata
       - git
       - pd-ggee
+      - a2jmidid
 
   - name: clone dspi git repo
     git:


### PR DESCRIPTION
Fixed a bug where guitarix couldn't actually be launched, and it wasn't automatically connected. Pretty much useless guitarix dspi is now useful!